### PR TITLE
Changed the way the Worker Thread is started

### DIFF
--- a/02_nanoFramework/Code/Program.cs
+++ b/02_nanoFramework/Code/Program.cs
@@ -35,6 +35,9 @@ namespace TechDays2021
         private static int counter = 0;
         private static int Warning = 0;
 
+        // Worker Thread
+        private static Thread workerThread = new Thread(WorkerThread);
+
         public static void Main()
         {
             // Connect the ESP32 Device to the Wifi and check the connection...
@@ -89,27 +92,32 @@ namespace TechDays2021
 
         public static string DirectMethodFlightStatus(int rid, string payload)
         {
+            // Incoming payload...
+            Debug.WriteLine($"Call back called :-) rid={rid}, payload={payload}");
+
             payload = payload.ToUpper();
             Debug.WriteLine($"The flight status recieved - {payload} ");
             // Reset the File Counter ready to start...
             flightDataStore.FileCount = 1;
-            // Update the Twin Report...
-            UpdateDeviceTwinReport();
 
             if (payload.Contains("STOP"))
             {
                 // Stop the thread...
                 runThread = false;
+                // Suspend the workerthread so that the device halts sending data.
+                workerThread.Suspend();
             }
             else
             {
                 // Start the thread...
                 runThread = true;
-                // Launch worker thread where the real work is done!...
-                new Thread(WorkerThread).Start();
+                // Start worker thread where the real work is done!...
+                workerThread.Start();
             }
-            // Update
-            return $"Flight status changed to - {payload}";
+            // Update the Twin Report...
+            UpdateDeviceTwinReport();
+
+            return "{\"Success\":\"OK\"}";
         }
 
         private static void FlightFinished()

--- a/02_nanoFramework/Code/Program.cs
+++ b/02_nanoFramework/Code/Program.cs
@@ -99,6 +99,8 @@ namespace TechDays2021
             Debug.WriteLine($"The flight status recieved - {payload} ");
             // Reset the File Counter ready to start...
             flightDataStore.FileCount = 1;
+            //Create a holder for the return message
+            string rtnMessage = "";
 
             if (payload.Contains("STOP"))
             {
@@ -106,18 +108,27 @@ namespace TechDays2021
                 runThread = false;
                 // Suspend the workerthread so that the device halts sending data.
                 workerThread.Suspend();
+                // Update the return message...
+                rtnMessage = "{\"Status\":\"Flight Stopped\"}";
             }
-            else
+            else if (payload.Contains("START"))
             {
                 // Start the thread...
                 runThread = true;
                 // Start worker thread where the real work is done!...
                 workerThread.Start();
+                // Update the return message...
+                rtnMessage = "{\"Status\":\"Flight Started\"}";
+            }
+            else
+            {
+                // Message recieved wasn't a known command so return a helpful ERROR message...
+                rtnMessage = "{\"ERROR\":\"Unknown command please use START or STOP...\"}";
             }
             // Update the Twin Report...
             UpdateDeviceTwinReport();
 
-            return "{\"Success\":\"OK\"}";
+            return rtnMessage;
         }
 
         private static void FlightFinished()


### PR DESCRIPTION
Changed the way the Worker Thread is started so that it can be suspended and thus solve the issue of the thread not ending until after the end of the Task.delay() as this caused a problem where a DirectMethod call could stop the flight and start again but nothing would have happened as the Thread was blocked...